### PR TITLE
Replace printf() with puts() and add cthreads_error_code() as well as cthreads_error_string()

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,8 @@ CThreads is an extremely portable threading library, allowing you to use the sam
 - `cthreads_rwlock_unlock`: Unlocks a read-write lock. Locked by `CTHREADS_RWLOCK`.
 - `cthreads_rwlock_wrlock`: Acquires a write lock on a read-write lock. Locked by `CTHREADS_RWLOCK`.
 - `cthreads_rwlock_destroy`: Destroys a read-write lock. Locked by `CTHREADS_RWLOCK`.
+- `cthreads_error_code`: Gets the platform-specific error code after an operation
+- `cthreads_error_string`: Writes the platform-specific error message into a user-provided buffer.
 
 > [!NOTE]
 > For internal information of what functions are used on certain platform, see `cthreads.h` file.

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ CThreads is an extremely portable threading library, allowing you to use the sam
 - `cthreads_rwlock_unlock`: Unlocks a read-write lock. Locked by `CTHREADS_RWLOCK`.
 - `cthreads_rwlock_wrlock`: Acquires a write lock on a read-write lock. Locked by `CTHREADS_RWLOCK`.
 - `cthreads_rwlock_destroy`: Destroys a read-write lock. Locked by `CTHREADS_RWLOCK`.
-- `cthreads_error_code`: Gets the platform-specific error code after an operation
+- `cthreads_error_code`: Gets the platform-specific error code after an operation.
 - `cthreads_error_string`: Writes the platform-specific error message into a user-provided buffer.
 
 > [!NOTE]

--- a/cthreads.c
+++ b/cthreads.c
@@ -457,14 +457,11 @@ int cthreads_cond_timedwait(struct cthreads_cond *cond, struct cthreads_mutex *m
       puts("cthreads_error_code");
     #endif
 
-    int error_code;
     #ifdef _WIN32
-      error_code = GetLastError();
+      return GetLastError();
     #else
-      error_code = errno;
+      return errno;
     #endif
-
-    return error_code;
   }
 
   size_t cthreads_error_string(size_t length, char buf[length], int error_code) {
@@ -478,7 +475,7 @@ int cthreads_cond_timedwait(struct cthreads_cond *cond, struct cthreads_mutex *m
       const size_t platform_error_str_size = FormatMessageA(FORMAT_MESSAGE_ALLOCATE_BUFFER | FORMAT_MESSAGE_FROM_SYSTEM | FORMAT_MESSAGE_IGNORE_INSERTS,
                                  NULL, error_code, MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT), (LPSTR)&platform_error_str, 0, NULL);
     #else
-      const char* platform_error_str = strerror(errno);
+      const char *platform_error_str = strerror(errno);
       const size_t platform_error_str_size = strlen(platform_error_str);
     #endif
 
@@ -487,6 +484,7 @@ int cthreads_cond_timedwait(struct cthreads_cond *cond, struct cthreads_mutex *m
       #ifdef _WIN32
         LocalFree(platform_error_str);
       #endif
+      
       return platform_error_str_size + 1;
     }
 

--- a/cthreads.c
+++ b/cthreads.c
@@ -6,8 +6,6 @@
 #include <errno.h>  /* errno */
 #include <string.h> /* strerror(), strlen() */
 #endif
-/* GetLastError() is defined in windows.h,
- * which is already included in cthreads.h */
 
 #include "cthreads.h"
 

--- a/cthreads.c
+++ b/cthreads.c
@@ -19,7 +19,7 @@ DWORD WINAPI __cthreads_winthreads_function_wrapper(void *data) {
 int cthreads_thread_create(struct cthreads_thread *thread, struct cthreads_thread_attr *attr, void *(*func)(void *data), void *data, struct cthreads_args *args) {
   #ifdef _WIN32
     #ifdef CTHREADS_DEBUG
-      printf("cthreads_thread_create\n");
+      puts("cthreads_thread_create");
     #endif
 
     args->func = func;
@@ -37,7 +37,7 @@ int cthreads_thread_create(struct cthreads_thread *thread, struct cthreads_threa
     (void) args;
 
     #ifdef CTHREADS_DEBUG
-      printf("cthreads_thread_create\n");
+      puts("cthreads_thread_create");
     #endif
 
     if (attr) {
@@ -61,7 +61,7 @@ int cthreads_thread_create(struct cthreads_thread *thread, struct cthreads_threa
 
 int cthreads_thread_detach(struct cthreads_thread thread) {
   #ifdef CTHREADS_DEBUG
-    printf("cthreads_thread_detach\n");
+    puts("cthreads_thread_detach");
   #endif
 
   #ifdef _WIN32
@@ -73,7 +73,7 @@ int cthreads_thread_detach(struct cthreads_thread thread) {
 
 int cthreads_thread_join(struct cthreads_thread thread, void *code) {
   #ifdef CTHREADS_DEBUG
-    printf("cthreads_thread_join\n");
+    puts("cthreads_thread_join");
   #endif
 
   #ifdef _WIN32
@@ -87,7 +87,7 @@ int cthreads_thread_join(struct cthreads_thread thread, void *code) {
 
 int cthreads_thread_equal(struct cthreads_thread thread1, struct cthreads_thread thread2) {
   #ifdef CTHREADS_DEBUG
-    printf("cthreads_thread_equal\n");
+    puts("cthreads_thread_equal");
   #endif
 
   #ifdef _WIN32
@@ -101,7 +101,7 @@ struct cthreads_thread cthreads_thread_self(void) {
   struct cthreads_thread t;
 
   #ifdef CTHREADS_DEBUG
-    printf("cthreads_thread_self\n");
+    puts("cthreads_thread_self");
   #endif
 
   #ifdef _WIN32
@@ -115,7 +115,7 @@ struct cthreads_thread cthreads_thread_self(void) {
 
 unsigned long cthreads_thread_id(struct cthreads_thread thread) {
   #ifdef CTHREADS_DEBUG
-    printf("cthreads_thread_id\n");
+    puts("cthreads_thread_id");
   #endif
 
   #ifdef _WIN32
@@ -127,7 +127,7 @@ unsigned long cthreads_thread_id(struct cthreads_thread thread) {
 
 void cthreads_thread_exit(void *code) {
   #ifdef CTHREADS_DEBUG
-    printf("cthreads_thread_exit\n");
+    puts("cthreads_thread_exit");
   #endif
 
   #ifdef _WIN32
@@ -143,7 +143,7 @@ void cthreads_thread_exit(void *code) {
 
 int cthreads_thread_cancel(struct cthreads_thread thread) {
   #ifdef CTHREADS_DEBUG
-    printf("cthreads_thread_cancel\n");
+    puts("cthreads_thread_cancel");
   #endif
 
   #ifdef _WIN32
@@ -160,7 +160,7 @@ int cthreads_thread_cancel(struct cthreads_thread thread) {
 #endif
   #ifdef _WIN32
     #ifdef CTHREADS_DEBUG
-      printf("cthreads_mutex_init\n");
+      puts("cthreads_mutex_init");
     #endif
 
     (void) attr;
@@ -172,7 +172,7 @@ int cthreads_thread_cancel(struct cthreads_thread thread) {
     pthread_mutexattr_t pAttr;
 
     #ifdef CTHREADS_DEBUG
-      printf("cthreads_mutex_init\n");
+      puts("cthreads_mutex_init");
     #endif
   
     /* CTHREADS_MUTEX_ATTR is always available on non-Windows platforms */
@@ -199,7 +199,7 @@ int cthreads_thread_cancel(struct cthreads_thread thread) {
 
 int cthreads_mutex_lock(struct cthreads_mutex *mutex) {
   #ifdef CTHREADS_DEBUG
-    printf("cthreads_mutex_lock\n");
+    puts("cthreads_mutex_lock");
   #endif
 
   #ifdef _WIN32
@@ -213,7 +213,7 @@ int cthreads_mutex_lock(struct cthreads_mutex *mutex) {
 
 int cthreads_mutex_trylock(struct cthreads_mutex *mutex) {
   #ifdef CTHREADS_DEBUG
-    printf("cthreads_mutex_trylock\n");
+    puts("cthreads_mutex_trylock");
   #endif
 
   #ifdef _WIN32
@@ -227,7 +227,7 @@ int cthreads_mutex_trylock(struct cthreads_mutex *mutex) {
 
 int cthreads_mutex_unlock(struct cthreads_mutex *mutex) {
   #ifdef CTHREADS_DEBUG
-    printf("cthreads_mutex_unlock\n");
+    puts("cthreads_mutex_unlock");
   #endif
 
   #ifdef _WIN32
@@ -241,7 +241,7 @@ int cthreads_mutex_unlock(struct cthreads_mutex *mutex) {
 
 int cthreads_mutex_destroy(struct cthreads_mutex *mutex) {
   #ifdef CTHREADS_DEBUG
-    printf("cthreads_mutex_destroy\n");
+    puts("cthreads_mutex_destroy");
   #endif
 
   #ifdef _WIN32
@@ -259,7 +259,7 @@ int cthreads_mutex_destroy(struct cthreads_mutex *mutex) {
   int cthreads_cond_init(struct cthreads_cond *cond, void *attr) {
 #endif
   #ifdef CTHREADS_DEBUG
-    printf("cthreads_cond_init\n");
+    puts("cthreads_cond_init");
   #endif
 
   #ifdef _WIN32
@@ -286,7 +286,7 @@ int cthreads_mutex_destroy(struct cthreads_mutex *mutex) {
 
 int cthreads_cond_signal(struct cthreads_cond *cond) {
   #ifdef CTHREADS_DEBUG
-    printf("cthreads_cond_signal\n");
+    puts("cthreads_cond_signal");
   #endif
 
   #ifdef _WIN32
@@ -300,7 +300,7 @@ int cthreads_cond_signal(struct cthreads_cond *cond) {
 
 int cthreads_cond_broadcast(struct cthreads_cond *cond) {
   #ifdef CTHREADS_DEBUG
-    printf("cthreads_cond_broadcast\n");
+    puts("cthreads_cond_broadcast");
   #endif
 
   #ifdef _WIN32
@@ -314,7 +314,7 @@ int cthreads_cond_broadcast(struct cthreads_cond *cond) {
 
 int cthreads_cond_destroy(struct cthreads_cond *cond) {
   #ifdef CTHREADS_DEBUG
-    printf("cthreads_cond_destroy\n");
+    puts("cthreads_cond_destroy");
   #endif
 
   #ifdef _WIN32
@@ -326,7 +326,7 @@ int cthreads_cond_destroy(struct cthreads_cond *cond) {
 
 int cthreads_cond_wait(struct cthreads_cond *cond, struct cthreads_mutex *mutex) {
   #ifdef CTHREADS_DEBUG
-    printf("cthreads_cond_wait\n");
+    puts("cthreads_cond_wait");
   #endif
 
   #ifdef _WIN32
@@ -338,7 +338,7 @@ int cthreads_cond_wait(struct cthreads_cond *cond, struct cthreads_mutex *mutex)
 
 int cthreads_cond_timedwait(struct cthreads_cond *cond, struct cthreads_mutex *mutex, unsigned int ms) {
   #ifdef CTHREADS_DEBUG
-    printf("cthreads_cond_wait\n");
+    puts("cthreads_cond_wait");
   #endif
 
   #ifdef _WIN32
@@ -357,7 +357,7 @@ int cthreads_cond_timedwait(struct cthreads_cond *cond, struct cthreads_mutex *m
 #ifdef CTHREADS_RWLOCK
   int cthreads_rwlock_init(struct cthreads_rwlock *rwlock) {
     #ifdef CTHREADS_DEBUG
-      printf("cthreads_rwlock_init\n");
+      puts("cthreads_rwlock_init");
     #endif
 
     #ifdef _WIN32
@@ -374,7 +374,7 @@ int cthreads_cond_timedwait(struct cthreads_cond *cond, struct cthreads_mutex *m
 
   int cthreads_rwlock_rdlock(struct cthreads_rwlock *rwlock) {
     #ifdef CTHREADS_DEBUG
-      printf("cthreads_rwlock_rdlock\n");
+      puts("cthreads_rwlock_rdlock");
     #endif
 
     #ifdef _WIN32
@@ -389,7 +389,7 @@ int cthreads_cond_timedwait(struct cthreads_cond *cond, struct cthreads_mutex *m
 
   int cthreads_rwlock_unlock(struct cthreads_rwlock *rwlock) {
     #ifdef CTHREADS_DEBUG
-      printf("cthreads_rwlock_unlock\n");
+      puts("cthreads_rwlock_unlock");
     #endif
 
     #ifdef _WIN32
@@ -416,7 +416,7 @@ int cthreads_cond_timedwait(struct cthreads_cond *cond, struct cthreads_mutex *m
 
   int cthreads_rwlock_wrlock(struct cthreads_rwlock *rwlock) {
     #ifdef CTHREADS_DEBUG
-      printf("cthreads_rwlock_wrlock\n");
+      puts("cthreads_rwlock_wrlock");
     #endif
 
     #ifdef _WIN32
@@ -431,7 +431,7 @@ int cthreads_cond_timedwait(struct cthreads_cond *cond, struct cthreads_mutex *m
 
   int cthreads_rwlock_destroy(struct cthreads_rwlock *rwlock) {
     #ifdef CTHREADS_DEBUG
-      printf("cthreads_rwlock_destroy\n");
+      puts("cthreads_rwlock_destroy");
     #endif
 
     #ifdef _WIN32

--- a/cthreads.c
+++ b/cthreads.c
@@ -3,8 +3,8 @@
 #include <stdint.h>
 
 #ifndef _WIN32
-#include <errno.h>  /* errno */
-#include <string.h> /* strerror(), strlen() */
+  #include <errno.h>  /* errno */
+  #include <string.h> /* strerror(), strlen() */
 #endif
 
 #include "cthreads.h"

--- a/cthreads.c
+++ b/cthreads.c
@@ -470,28 +470,28 @@ int cthreads_cond_timedwait(struct cthreads_cond *cond, struct cthreads_mutex *m
     #ifdef _WIN32
       LPSTR platform_error_str = NULL;
       /* INFO: Get length and print message to newly allocated buffer "platform_error_str" */
-      const size_t platform_error_str_size = FormatMessageA(FORMAT_MESSAGE_ALLOCATE_BUFFER | FORMAT_MESSAGE_FROM_SYSTEM | FORMAT_MESSAGE_IGNORE_INSERTS,
+      const size_t platform_error_str_len = FormatMessageA(FORMAT_MESSAGE_ALLOCATE_BUFFER | FORMAT_MESSAGE_FROM_SYSTEM | FORMAT_MESSAGE_IGNORE_INSERTS,
                                  NULL, error_code, MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT), (LPSTR)&platform_error_str, 0, NULL);
     #else
       const char *platform_error_str = strerror(errno);
-      const size_t platform_error_str_size = strlen(platform_error_str);
+      const size_t platform_error_str_len = strlen(platform_error_str);
     #endif
 
 
-    if (platform_error_str_size >= length) {
+    if (platform_error_str_len >= length) {
       #ifdef _WIN32
         LocalFree(platform_error_str);
       #endif
       
-      return platform_error_str_size + 1;
+      return platform_error_str_len + 1;
     }
 
-    memcpy(buf, platform_error_str, platform_error_str_size);
+    memcpy(buf, platform_error_str, platform_error_str_len);
 
     #ifdef _WIN32
       LocalFree(platform_error_str);
     #endif
 
-    return platform_error_str_size + 1;
+    return platform_error_str_len + 1;
   }
 #endif

--- a/cthreads.c
+++ b/cthreads.c
@@ -474,7 +474,7 @@ int cthreads_cond_timedwait(struct cthreads_cond *cond, struct cthreads_mutex *m
 
     #ifdef _WIN32
       LPSTR platform_error_str = NULL;
-      /* Get length and print message to newly allocated buffer `platform_error_str` */
+      /* INFO: Get length and print message to newly allocated buffer "platform_error_str" */
       const size_t platform_error_str_size = FormatMessageA(FORMAT_MESSAGE_ALLOCATE_BUFFER | FORMAT_MESSAGE_FROM_SYSTEM | FORMAT_MESSAGE_IGNORE_INSERTS,
                                  NULL, error_code, MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT), (LPSTR)&platform_error_str, 0, NULL);
     #else

--- a/cthreads.c
+++ b/cthreads.c
@@ -2,8 +2,10 @@
 #include <stdlib.h>
 #include <stdint.h>
 
-#include <errno.h>  /* For errno */
-#include <string.h> /* For strerror() and strlen() */
+#ifndef _WIN32
+#include <errno.h>  /* errno */
+#include <string.h> /* strerror(), strlen() */
+#endif
 /* GetLastError() is defined in windows.h,
  * which is already included in cthreads.h */
 

--- a/cthreads.h
+++ b/cthreads.h
@@ -421,6 +421,28 @@ int cthreads_cond_timedwait(struct cthreads_cond *cond, struct cthreads_mutex *m
    * @return 0 on success, non-zero error code on failure.
    */
   int cthreads_rwlock_destroy(struct cthreads_rwlock *rwlock);
+
+  /**
+   * Returns the platform-specific error code.
+   *
+   * - pthread: errno
+   * - windows: GetLastError()
+   *
+   * @return Platform-specific error code
+   */
+  int cthreads_error_code(void);
+
+  /**
+   * Obtains the error code and writes at most `length` 
+   * bytes of the associated message to `buf`.
+   *
+   * @param length Length of the provided buffer
+   * @param buf Buffer of `length` bytes and target of the error message
+   * @param error_code Platform-specific error code. (See: `cthreads_error_code()`)
+   *
+   * @return Number of bytes required to print the message + NULL-terminator
+   */
+  size_t cthreads_error_string(size_t length, char buf[length], int error_code);
 #endif
 
 #endif /* CTHREADS_H */


### PR DESCRIPTION
## Changes

> Commit 1: Changed all calls of `printf()` to calls of `puts()`.

> Commit 2: Add `int cthreads_error_code(void)` to obtain a platform-specific error code and `size_t cthreads_error_string(size_t length, char buf[length], int error_code)` to obtain an error-message.

## Why 

> Commit 1: `printf()`'s formatting is never used and is therefore, either replaced by the compiler with a call to `puts()` automatically, or wastes time trying to find formatting.

> Commit 2: There is currently no way to obtain an error-message for the functions (hence `cthreads_error_string`) and the error codes returned by the functions aren't always the correct code.


## Checkmarks

- [x] The modified functions have been tested. (on Linux and mingw only)
- [x] Used the same indentation as the rest of the project.
