### PR TITLE
add: memory based semaphores.

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,12 @@ CThreads is an extremely portable threading library, allowing you to use the sam
 - `cthreads_rwlock_destroy`: Destroys a read-write lock. Locked by `CTHREADS_RWLOCK`.
 - `cthreads_error_code`: Gets the platform-specific error code after an operation.
 - `cthreads_error_string`: Writes the platform-specific error message into a user-provided buffer.
+- `cthreads_sem_init`: Initializes a semaphore. Locked by `CTHREADS_SEMAPHORE`.
+- `cthreads_sem_wait`: Decrements a semaphore. Locked by `CTHREADS_SEMAPHORE`.
+- `cthreads_sem_trywait`: Tries to decrement a semaphore without blocking. Locked by `CTHREADS_SEMAPHORE`.
+- `cthreads_cond_timedwait`: Tries to decrement a semaphore till ms. Locked by `CTHREADS_SEMAPHORE`.
+- `cthreads_sem_post`: Increments a semaphore. Locked by `CTHREADS_SEMAPHORE`.
+- `cthreads_sem_destroy`: Destroys a semaphore. Locked by `CTHREADS_SEMAPHORE`.
 
 > [!NOTE]
 > For internal information of what functions are used on certain platform, see `cthreads.h` file.
@@ -69,6 +75,7 @@ Those macros are:
 - `CTHREADS_COND_PSHARED`
 - `CTHREADS_COND_CLOCK`
 - `CTHREADS_RWLOCK`
+- `CTHREADS_SEMAPHORE`
 
 > [!NOTE]
 > Any function/field that is not listed there is available on all platforms.

--- a/cthreads.c
+++ b/cthreads.c
@@ -574,4 +574,3 @@ size_t cthreads_error_string(int error_code, char *buf, size_t length) {
   }
 #endif
 
-

--- a/cthreads.c
+++ b/cthreads.c
@@ -495,3 +495,85 @@ int cthreads_cond_timedwait(struct cthreads_cond *cond, struct cthreads_mutex *m
     return platform_error_str_len + 1;
   }
 #endif
+
+#ifdef CTHREADS_SEMAPHORE
+  int cthreads_sem_init(struct cthreads_semaphore *sem, int initial_count) {
+    #ifdef CTHREADS_DEBUG
+      puts("cthreads_sem_init");
+    #endif
+  
+    #ifdef _WIN32
+      sem->wSemaphore = CreateSemaphore(NULL, initial_count, LONG_MAX, NULL);
+
+      return sem->wSemaphore == NULL;
+    #else
+      return sem_init(&sem->pSemaphore,0, initial_count);
+    #endif
+  }
+  
+  int cthreads_sem_wait(struct cthreads_semaphore *sem) {
+    #ifdef CTHREADS_DEBUG
+      puts("cthreads_sem_wait");
+    #endif
+
+    #ifdef _WIN32
+      return (WaitForSingleObject(sem->wSemaphore, INFINITE) != WAIT_OBJECT_0);
+    #else
+      return sem_wait(&sem->pSemaphore);
+    #endif
+  }
+  
+  int cthreads_sem_trywait(struct cthreads_semaphore *sem) {
+    #ifdef CTHREADS_DEBUG
+      puts("cthreads_sem_trywait");
+    #endif
+
+    #ifdef _WIN32
+      return (WaitForSingleObject(sem->wSemaphore, 0) == WAIT_TIMEOUT);
+    #else
+      return sem_trywait(&sem->pSemaphore);
+    #endif
+  }
+  
+  int cthreads_sem_timedwait(struct cthreads_semaphore *sem, unsigned int ms) {
+    #ifdef CTHREADS_DEBUG
+      puts("cthreads_sem_timedwait");
+    #endif
+
+    #ifdef _WIN32
+      return (WaitForSingleObject(sem->wSemaphore, (DWORD)ms) == WAIT_TIMEOUT);
+    #else
+      struct timespec ts;
+      if (clock_gettime(CLOCK_REALTIME, &ts)) return 1;
+ 
+      ts.tv_sec += ms / 1000;
+      ts.tv_nsec += (ms % 1000) * 1000000;
+ 
+      return sem_timedwait(&sem->pSemaphore, &ts);
+    #endif
+  }
+  int cthreads_sem_post(struct cthreads_semaphore *sem) {
+    #ifdef CTHREADS_DEBUG
+      puts("cthreads_sem_post");
+    #endif
+
+    #ifdef _WIN32
+      return ReleaseSemaphore(sem->wSemaphore, 1, NULL);
+    #else
+      return sem_post(&sem->pSemaphore);
+    #endif
+  }
+  
+  int cthreads_sem_destroy(struct cthreads_semaphore *sem) {
+    #ifdef CTHREADS_DEBUG
+      puts("cthreads_sem_destroy");
+    #endif
+
+    #ifdef _WIN32
+      return CloseHandle(sem->wSemaphore);
+    #else
+      return sem_destroy(&sem->pSemaphore);
+    #endif
+  }
+#endif
+

--- a/cthreads.h
+++ b/cthreads.h
@@ -8,6 +8,7 @@ struct cthreads_args {
 
 #ifdef _WIN32
   #include <windows.h>
+  #define CTHREADS_SEMAPHORE 1
 #else
   #include <pthread.h>
 #endif
@@ -26,6 +27,8 @@ struct cthreads_args {
   #define CTHREADS_THREAD_SCHEDPOLICY 1
   #define CTHREADS_THREAD_SCOPE 1
   #if _POSIX_C_SOURCE >= 200112L
+    #include <semaphore.h>
+    #define CTHREADS_SEMAPHORE 1
     #define CTHREADS_THREAD_STACK 1
   #endif
 
@@ -140,6 +143,15 @@ struct cthreads_rwlock {
 };
 #endif
 
+#ifdef CTHREADS_SEMAPHORE
+  struct cthreads_semaphore {
+    #ifdef _WIN32
+      HANDLE wSemaphore;
+    #else
+      sem_t pSemaphore;
+    #endif
+  };
+#endif
 /**
  * Creates a new thread.
  *
@@ -443,6 +455,77 @@ int cthreads_cond_timedwait(struct cthreads_cond *cond, struct cthreads_mutex *m
    * @return Number of bytes required to print the message + NULL-terminator
    */
   size_t cthreads_error_string(size_t length, char buf[length], int error_code);
+#endif
+
+#ifdef CTHREADS_SEMAPHORE
+  /**
+  * Initializes a semaphore.
+  *
+  * - pthread: sem_init()
+  * - windows threads: CreateSemaphore()
+  *
+  * @param semaphore Pointer to the semaphore structure to be initialized.
+  * @param initial count of the semaphore
+  * @return 0 on success, non-zero error code on failure.
+  */
+  int cthreads_sem_init(struct cthreads_semaphore *sem, int initial_count);
+
+  /**
+  * Decrease a semaphore.
+  *
+  * - pthread: sem_wait()
+  * - windows threads: WaitForSingleObject()
+  *
+  * @param semaphore Pointer to the semaphore structure to be decreased.
+  * @return 0 on success, non-zero error code on failure.
+  */
+  int cthreads_sem_wait(struct cthreads_semaphore *sem);
+
+  /**
+  * Tries to decrease a semaphore without blocking.
+  *
+  * - pthread: sem_trywait()
+  * - windows threads: WaitForSingleObject()
+  *
+  * @param semaphore Pointer to the semaphore structure to be decreased.
+  * @return 0 on success, non-zero error code on failure.
+  */
+  int cthreads_sem_trywait(struct cthreads_semaphore *sem);
+
+
+  /**
+  * Waits on a condition variable till set ms.
+  *
+  * - pthread: sem_timedwait
+  * - windows threads: WaitForSingleObject()
+  *
+  * @param semaphore Pointer to the semaphore structure to be decreased.
+  * @param ms Time in milliseconds to unlock if not unlocked in time.
+  * @return 0 on success, non-zero error code on failure.
+  */
+  int cthreads_sem_timedwait(struct cthreads_semaphore *sem, unsigned int ms);
+
+  /**
+  * Increase a semaphore.
+  *
+  * - pthread: sem_post()
+  * - windows threads: ReleaseSemaphore()
+  *
+  * @param semaphore Pointer to the semaphore structure to be increased.
+  * @return 0 on success, non-zero error code on failure.
+  */
+  int cthreads_sem_post(struct cthreads_semaphore *sem);
+
+  /**
+  * Destroy a semaphore.
+  *
+  * - pthread: sem_destroy()
+  * - windows threads: CloseHandle()
+  *
+  * @param semaphore Pointer to the semaphore structure to be destroyed.
+  * @return 0 on success, non-zero error code on failure.
+  */
+  int cthreads_sem_destroy(struct cthreads_semaphore *sem);
 #endif
 
 #endif /* CTHREADS_H */


### PR DESCRIPTION
## Changes
This commit adds the following functions for semaphores:
- `cthreads_sem_init`
- `cthreads_sem_post`
- `cthreads_sem_wait`
- `cthreads_sem_trywait`
- `cthreads_sem_timedwait`
- `cthreads_sem_destroy`

## Why 

Semaphores are fundamental synchronization primitives that are already available in `windows.h` and can be included for POSIX with `semaphore.h` at a low cost.

## Checkmarks

- [x] The modified functions have been tested (with GCC for Linux and MSVC for Windows).
- [x] Used the same indentation as the rest of the project.

## Additional information

File-based/named semaphores for inter-process synchronization are part of both  `windows.h` and  `semaphore.h` but they are not implemented.