### PR TITLE
Make function signature of `cthreads_error_string()` dependent on if the compiler supports it for better warnings.

### DIFF
--- a/cthreads.c
+++ b/cthreads.c
@@ -465,7 +465,7 @@ int cthreads_cond_timedwait(struct cthreads_cond *cond, struct cthreads_mutex *m
   }
 #endif
 
-#if CTHREADS_STATIC_VLA == 1
+#ifdef CTHREADS_SUPPORTS_VLA
 size_t cthreads_error_string(int error_code, size_t length, char buf[static length]) {
 #else
 size_t cthreads_error_string(int error_code, size_t length, char *buf) {
@@ -480,7 +480,7 @@ size_t cthreads_error_string(int error_code, size_t length, char *buf) {
     /* 
       INFO: The string that is written also contains a \n, which we must ignore, besides the
               NULL terminator.
-    */
+    */Update cthreads.c
     const size_t error_str_len = FormatMessageA(FORMAT_MESSAGE_ALLOCATE_BUFFER | FORMAT_MESSAGE_FROM_SYSTEM | FORMAT_MESSAGE_IGNORE_INSERTS,
                                 NULL, error_code, MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT), (LPSTR)&error_str, 0, NULL) - 1 - 1;
   #else

--- a/cthreads.c
+++ b/cthreads.c
@@ -7,6 +7,8 @@
   #include <string.h> /* strerror(), strlen() */
 #endif
 
+#include <time.h>
+
 #include "cthreads.h"
 
 #ifdef _WIN32
@@ -463,7 +465,11 @@ int cthreads_cond_timedwait(struct cthreads_cond *cond, struct cthreads_mutex *m
   }
 #endif
 
-size_t cthreads_error_string(int error_code, char *buf, size_t length) {
+#if CTHREADS_STATIC_VLA == 1
+size_t cthreads_error_string(int error_code, size_t length, char buf[static length]) {
+#else
+size_t cthreads_error_string(int error_code, size_t length, char *buf) {
+#endif
   #ifdef CTHREADS_DEBUG
     puts("cthreads_error_string");
   #endif

--- a/cthreads.c
+++ b/cthreads.c
@@ -466,9 +466,9 @@ int cthreads_cond_timedwait(struct cthreads_cond *cond, struct cthreads_mutex *m
 #endif
 
 #ifdef CTHREADS_SUPPORTS_VLA
-size_t cthreads_error_string(int error_code, size_t length, char buf[static length]) {
+  size_t cthreads_error_string(int error_code, size_t length, char buf[static length]) {
 #else
-size_t cthreads_error_string(int error_code, size_t length, char *buf) {
+  size_t cthreads_error_string(int error_code, size_t length, char *buf) {
 #endif
   #ifdef CTHREADS_DEBUG
     puts("cthreads_error_string");

--- a/cthreads.h
+++ b/cthreads.h
@@ -448,7 +448,7 @@ int cthreads_cond_timedwait(struct cthreads_cond *cond, struct cthreads_mutex *m
 
 #if ((defined(__GNUC__) || defined(__clang__) || defined(__TINYC__)) && __STDC__ == 1 && __STDC_VERSION__ >= 199901L) \
     || (__STDC__ == 0 && __STDC_VERSION__ >= 201112L)
-#define CTHREADS_STATIC_VLA 1
+#define CTHREADS_SUPPORTS_VLA
 #else
 #define CTHREADS_STATIC_VLA 0
 #endif

--- a/cthreads.h
+++ b/cthreads.h
@@ -433,16 +433,27 @@ int cthreads_cond_timedwait(struct cthreads_cond *cond, struct cthreads_mutex *m
   int cthreads_error_code(void);
 #endif
 
+#if ((defined(__GNUC__) || defined(__clang__) || defined(__TINYC__)) && __STDC__ == 1 && __STDC_VERSION__ >= 199901L) \
+    || (__STDC__ == 0 && __STDC_VERSION__ >= 201112L)
+#define CTHREADS_STATIC_VLA 1
+#else
+#define CTHREADS_STATIC_VLA 0
+#endif
+
 /**
  * Obtains the error code and writes at most `length` 
  * bytes of the associated message to `buf`.
  *
- * @param error_code Platform-specific error code. (See: `cthreads_error_code()`)
- * @param buf Buffer of `length` bytes and target of the error message
+ * @param error_code Platform-specific error code. @see \ref cthreads_error_code()
  * @param length Length of the provided buffer
+ * @param buf Buffer of at least `length` bytes and target of the error message
  *
  * @return Number of bytes required to print the message + NULL-terminator
  */
-size_t cthreads_error_string(int error_code, char *buf, size_t length);
+#if CTHREADS_STATIC_VLA == 1
+size_t cthreads_error_string(int error_code, size_t length, char buf[static length]);
+#else
+size_t cthreads_error_string(int error_code, size_t length, char* buf);
+#endif
 
 #endif /* CTHREADS_H */

--- a/cthreads.h
+++ b/cthreads.h
@@ -446,11 +446,11 @@ int cthreads_cond_timedwait(struct cthreads_cond *cond, struct cthreads_mutex *m
   int cthreads_error_code(void);
 #endif
 
+/* Check for static vla support ( (is_compiler(gcc or clang or tcc) and complies_with(C99))
+ *                               or complies_with(C11) Update cthreads.c) */
 #if ((defined(__GNUC__) || defined(__clang__) || defined(__TINYC__)) && __STDC__ == 1 && __STDC_VERSION__ >= 199901L) \
     || (__STDC__ == 0 && __STDC_VERSION__ >= 201112L)
 #define CTHREADS_SUPPORTS_VLA
-#else
-#define CTHREADS_STATIC_VLA 0
 #endif
 
 /**
@@ -463,7 +463,7 @@ int cthreads_cond_timedwait(struct cthreads_cond *cond, struct cthreads_mutex *m
  *
  * @return Number of bytes required to print the message + NULL-terminator
  */
-#if CTHREADS_STATIC_VLA == 1
+#ifdef CTHREADS_SUPPORTS_VLA
 size_t cthreads_error_string(int error_code, size_t length, char buf[static length]);
 #else
 size_t cthreads_error_string(int error_code, size_t length, char* buf);

--- a/cthreads.h
+++ b/cthreads.h
@@ -464,9 +464,9 @@ int cthreads_cond_timedwait(struct cthreads_cond *cond, struct cthreads_mutex *m
  * @return Number of bytes required to print the message + NULL-terminator
  */
 #ifdef CTHREADS_SUPPORTS_VLA
-size_t cthreads_error_string(int error_code, size_t length, char buf[static length]);
+  size_t cthreads_error_string(int error_code, size_t length, char buf[static length]);
 #else
-size_t cthreads_error_string(int error_code, size_t length, char* buf);
+  size_t cthreads_error_string(int error_code, size_t length, char *buf);
 #endif
 
 #ifdef CTHREADS_SEMAPHORE

--- a/cthreads.h
+++ b/cthreads.h
@@ -450,7 +450,7 @@ int cthreads_cond_timedwait(struct cthreads_cond *cond, struct cthreads_mutex *m
  *                               or complies_with(C11) Update cthreads.c) */
 #if ((defined(__GNUC__) || defined(__clang__) || defined(__TINYC__)) && __STDC__ == 1 && __STDC_VERSION__ >= 199901L) \
     || (__STDC__ == 0 && __STDC_VERSION__ >= 201112L)
-#define CTHREADS_SUPPORTS_VLA
+  #define CTHREADS_SUPPORTS_VLA
 #endif
 
 /**


### PR DESCRIPTION
## Changes

The `buf` parameter is now a static VLA, if the compiler supports it, this gives better warnings if the function is used improperly (passing NULL or an array that is too short.)

## Why 

This improves warnings and therefore experience with CThreads.

## Checkmarks

- [x] The modified functions have been tested.
  - Both on MSVC and GCC.
- [x] Used the same indentation as the rest of the project.

## Additional information
**THIS CHANGES THE SIGNATURE OF THIS FUNCTION!**