### PR TITLE
Fix some miscellaneous MSVC warnings

### DIFF
--- a/cthreads.c
+++ b/cthreads.c
@@ -136,7 +136,11 @@ void cthreads_thread_exit(void *code) {
   #endif
 
   #ifdef _WIN32
-    #if defined  __WATCOMC__ || _MSC_VER || __DMC__
+    /* NOTE: This gives warnings on MSVC, so I removed this
+     * for the oldest version of it I could test (19.20). */
+    /* TODO: Test with the other described compilers if this
+     *       is _really_ necessary. */
+    #if defined  __WATCOMC__ || _MSC_VER < 1920 || __DMC__
       ExitThread((DWORD)code);
     #else
       ExitThread((DWORD)(uintptr_t)code);
@@ -323,6 +327,7 @@ int cthreads_cond_destroy(struct cthreads_cond *cond) {
   #endif
 
   #ifdef _WIN32
+    (void) cond;
     return 0;
   #else
     return pthread_cond_destroy(&cond->pCond);

--- a/cthreads.c
+++ b/cthreads.c
@@ -139,7 +139,7 @@ void cthreads_thread_exit(void *code) {
     /* NOTE: This gives warnings on MSVC, so I removed this
      * for the oldest version of it I could test (19.20). */
     /* TODO: Test with the other described compilers if this
-     *       is _really_ necessary. */
+     *       is REALLY necessary. */
     #if defined  __WATCOMC__ || _MSC_VER < 1920 || __DMC__
       ExitThread((DWORD)code);
     #else

--- a/cthreads.c
+++ b/cthreads.c
@@ -328,6 +328,7 @@ int cthreads_cond_destroy(struct cthreads_cond *cond) {
 
   #ifdef _WIN32
     (void) cond;
+
     return 0;
   #else
     return pthread_cond_destroy(&cond->pCond);

--- a/cthreads.h
+++ b/cthreads.h
@@ -7,6 +7,8 @@ struct cthreads_args {
 };
 
 #ifdef _WIN32
+  /* MSVC sees strncpy() as insecure. */
+  #define _CRT_SECURE_NO_WARNINGS
   #include <windows.h>
 #else
   #include <pthread.h>


### PR DESCRIPTION
## Changes

- Added definition `_CRT_SECURE_NO_WARNINGS` to fix a warning related to strncpy().
- Excluded newer versions of MSVC on (old) line 139.
- Added `(void) cond` in `cthreads_cond_destroy()` because it isn't used.

## Why 

Because nobody likes compile-time warnings.

## Checkmarks

- [x] The modified functions have been tested. (MSVC 19.20)
- [x] Used the same indentation as the rest of the project.

## Additional information
-