### PR TITLE
Fix cthreads_thread_detatch returning an incorrect error code

### DIFF
--- a/cthreads.c
+++ b/cthreads.c
@@ -70,7 +70,7 @@ int cthreads_thread_detach(struct cthreads_thread thread) {
   #endif
 
   #ifdef _WIN32
-    return CloseHandle(thread.wThread);
+    return CloseHandle(thread.wThread)==0;
   #else
     return pthread_detach(thread.pThread);
   #endif


### PR DESCRIPTION
This is a fix for [BUG]: cthreads_thread_detach does not return 0 upon success for windows threads